### PR TITLE
Update CMake for external projects to collect Git repository and tag info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,13 @@ IF(MSVC)
   ENDIF()
 ENDIF()
 
+# Macro to set the Git repository and tag, and display a message
+MACRO(SetGitRepositoryTag project_name git_repository git_tag)
+  SET(${project_name}_GIT_REPOSITORY ${git_repository})
+  SET(${project_name}_GIT_TAG ${git_tag})
+  MESSAGE(STATUS "${project_name} repository: ${git_repository} (${git_tag})")
+ENDMACRO(SetGitRepositoryTag)
+
 IF (PLUSBUILD_OFFLINE_BUILD)
   # Set an empty download and update command for external projects
   SET(PLUSBUILD_EXTERNAL_PROJECT_CUSTOM_COMMANDS DOWNLOAD_COMMAND "" UPDATE_COMMAND "")
@@ -116,10 +123,6 @@ OPTION(PLUSBUILD_USE_Tesseract "Use OCR in PlusLib for recognizing ultrasound im
 OPTION(PLUSBUILD_USE_OpenCV "Use OpenCV for optical marker tracking and other features." OFF)
 OPTION(PLUSBUILD_USE_aruco "Use aruco for optical marker tracking." OFF)
 OPTION(PLUSBUILD_DOWNLOAD_PLUSLIBDATA "Download sample and test data. Required for automatic tests." ON)
-IF(PLUSBUILD_DOWNLOAD_PLUSLIBDATA)
-  SET(PLUSBUILD_PLUSLIBDATA_GIT_REVISION "master" CACHE STRING "Set PlusLibData desired git hash (master means latest)." FORCE)
-  MARK_AS_ADVANCED(PLUSBUILD_PLUSLIBDATA_GIT_REVISION)
-ENDIF()
 
 # Documentation
 OPTION(PLUSBUILD_DOCUMENTATION "Build Plus documentation (Doxygen)." OFF)
@@ -276,10 +279,24 @@ IF(PLUS_USE_Ascension3DG AND PLUS_USE_Ascension3DGm)
 ENDIF()
 
 #-----------------------------------------------------------------------------
-# Plus revision - Set Plus stable relase revision (0 means latest)
+# Plus revision - Set Plus stable relase revision (master means latest)
 #-----------------------------------------------------------------------------
+SET(PLUSLIB_GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusLib.git" CACHE STRING "Set PlusLib desired git url")
+MARK_AS_ADVANCED(PLUSLIB_GIT_REPOSITORY)
 SET(PLUSLIB_GIT_REVISION "master" CACHE STRING "Set PlusLib desired git hash (master means latest)")
+MARK_AS_ADVANCED(PLUSLIB_GIT_REVISION)
+
+SET(PLUSAPP_GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusApp.git" CACHE STRING "Set PlusApp desired git url")
+MARK_AS_ADVANCED(PLUSAPP_GIT_REPOSITORY)
 SET(PLUSAPP_GIT_REVISION "master" CACHE STRING "Set PlusApp desired git hash (master means latest)")
+MARK_AS_ADVANCED(PLUSAPP_GIT_REVISION)
+
+IF(PLUSBUILD_DOWNLOAD_PLUSLIBDATA)
+  SET(PLUSBUILD_PLUSLIBDATA_GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusLibData.git" CACHE STRING "Set PlusLibData desired git url.")
+  MARK_AS_ADVANCED(PLUSBUILD_PLUSLIBDATA_GIT_REPOSITORY)
+  SET(PLUSBUILD_PLUSLIBDATA_GIT_REVISION "master" CACHE STRING "Set PlusLibData desired git hash (master means latest).")
+  MARK_AS_ADVANCED(PLUSBUILD_PLUSLIBDATA_GIT_REVISION)
+ENDIF()
 
 #-----------------------------------------------------------------------------
 # Plus executable output path

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -37,8 +37,11 @@ IF(ITK_DIR)
   SET (PLUS_ITK_DIR ${ITK_DIR} CACHE INTERNAL "Path to store itk binaries")
 ELSE()
   # ITK has not been built yet, so download and build it as an external project
-  SET (ITKv4_REPOSITORY ${GIT_PROTOCOL}://itk.org/ITK.git)
-  SET (ITKv4_GIT_TAG v4.12.0)
+  SetGitRepositoryTag(
+    itk
+    "${GIT_PROTOCOL}://itk.org/ITK.git"
+    "v4.12.0"
+    )
 
   IF(UNIX AND NOT APPLE)
     SET(itk_common_cxx_flags "${ep_common_cxx_flags} -std=c++11")
@@ -54,8 +57,8 @@ ELSE()
     SOURCE_DIR "${PLUS_ITK_SRC_DIR}"
     BINARY_DIR "${PLUS_ITK_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY "${ITKv4_REPOSITORY}"
-    GIT_TAG "${ITKv4_GIT_TAG}"
+    GIT_REPOSITORY ${itk_GIT_REPOSITORY}
+    GIT_TAG ${itk_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS 
       ${ep_common_args}

--- a/SuperBuild/External_IntersonSDKCxx.cmake
+++ b/SuperBuild/External_IntersonSDKCxx.cmake
@@ -28,8 +28,11 @@ IF(IntersonSDKCxx_DIR)
   SET(PLUS_IntersonSDKCxx_DIR "${IntersonSDKCxx_DIR}" CACHE INTERNAL "Path to store IntersonSDKCxx binaries")
 ELSE()
   # IntersonSDKCxx has not been built yet, so download and build it as an external project
-  SET (IntersonSDKCxx_REPOSITORY ${GIT_PROTOCOL}://github.com/KitwareMedical/IntersonSDKCxx.git)
-  SET (IntersonSDKCxx_GIT_TAG 819d620052be7e9b232e12d8946793c15cfbf5a3)
+  SetGitRepositoryTag(
+    IntersonSDKCxx
+    "${GIT_PROTOCOL}://github.com/KitwareMedical/IntersonSDKCxx.git"
+    "819d620052be7e9b232e12d8946793c15cfbf5a3"
+    )
 
   SET (PLUS_IntersonSDKCxx_SRC_DIR "${CMAKE_BINARY_DIR}/Deps/IntersonSDKCxx")
   SET (PLUS_IntersonSDKCxx_DIR "${CMAKE_BINARY_DIR}/Deps/IntersonSDKCxx-bin" CACHE INTERNAL "Path to store IntersonSDKCxx binaries")
@@ -38,8 +41,8 @@ ELSE()
     SOURCE_DIR "${PLUS_IntersonSDKCxx_SRC_DIR}"
     BINARY_DIR "${PLUS_IntersonSDKCxx_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY "${IntersonSDKCxx_REPOSITORY}"
-    GIT_TAG "${IntersonSDKCxx_GIT_TAG}"
+    GIT_REPOSITORY ${IntersonSDKCxx_GIT_REPOSITORY}
+    GIT_TAG ${IntersonSDKCxx_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS 
       ${ep_common_args}

--- a/SuperBuild/External_OpenCV.cmake
+++ b/SuperBuild/External_OpenCV.cmake
@@ -37,8 +37,6 @@ IF(OpenCV_DIR)
   # Create a dummy target
   ADD_CUSTOM_TARGET(OpenCV)
 ELSE()
-  # No OpenCV is specified, so download and build
-  SET(OpenCV_REPOSITORY https://github.com/opencv/opencv.git)
 
   FIND_PACKAGE(CUDA QUIET)
   
@@ -89,7 +87,12 @@ ELSE()
     LIST(APPEND OpenCV_PLATFORM_SPECIFIC_ARGS -DWITH_QT:BOOL=ON -DQt5_DIR:PATH=${Qt5_DIR})
   ENDIF()
 
-  MESSAGE(STATUS "Downloading OpenCV from: ${OpenCV_REPOSITORY}")
+  # No OpenCV is specified, so download and build
+  SetGitRepositoryTag(
+    OpenCV
+    "${GIT_PROTOCOL}://github.com/opencv/opencv.git"
+    "3.2.0"
+    )
 
   SET (PLUS_OpenCV_src_DIR ${CMAKE_BINARY_DIR}/Deps/OpenCV CACHE INTERNAL "Path to store OpenCV contents.")
   SET (PLUS_OpenCV_prefix_DIR ${CMAKE_BINARY_DIR}/Deps/OpenCV-prefix CACHE INTERNAL "Path to store OpenCV prefix data.")
@@ -100,8 +103,8 @@ ELSE()
     SOURCE_DIR "${PLUS_OpenCV_src_DIR}"
     BINARY_DIR "${PLUS_OpenCV_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY ${OpenCV_REPOSITORY}
-    GIT_TAG 3.2.0
+    GIT_REPOSITORY ${OpenCV_GIT_REPOSITORY}
+    GIT_TAG ${OpenCV_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS
       ${ep_common_args}

--- a/SuperBuild/External_OpenIGTLink.cmake
+++ b/SuperBuild/External_OpenIGTLink.cmake
@@ -30,8 +30,12 @@ IF(OpenIGTLink_DIR)
   SET (PLUS_OpenIGTLink_DIR "${OpenIGTLink_DIR}" CACHE INTERNAL "Path to store OpenIGTLink binaries")
 ELSE()
   # OpenIGTLink has not been built yet, so download and build it as an external project
-  MESSAGE(STATUS "Downloading OpenIGTLink from ${GIT_PROTOCOL}://github.com/openigtlink/OpenIGTLink.git.")
-  
+  SetGitRepositoryTag(
+    OpenIGTLink
+    "${GIT_PROTOCOL}://github.com/openigtlink/OpenIGTLink.git"
+    "master"
+    )
+
   SET (PLUS_OpenIGTLink_SRC_DIR "${CMAKE_BINARY_DIR}/Deps/OpenIGTLink")
   SET (PLUS_OpenIGTLink_DIR "${CMAKE_BINARY_DIR}/Deps/OpenIGTLink-bin" CACHE INTERNAL "Path to store OpenIGTLink binaries")
   ExternalProject_Add( OpenIGTLink
@@ -40,8 +44,8 @@ ELSE()
     SOURCE_DIR "${PLUS_OpenIGTLink_SRC_DIR}"
     BINARY_DIR "${PLUS_OpenIGTLink_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/openigtlink/OpenIGTLink.git"
-    GIT_TAG "master"
+    GIT_REPOSITORY ${OpenIGTLink_GIT_REPOSITORY}
+    GIT_TAG ${OpenIGTLink_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS 
       ${ep_common_args}

--- a/SuperBuild/External_OpenIGTLinkIO.cmake
+++ b/SuperBuild/External_OpenIGTLinkIO.cmake
@@ -27,7 +27,11 @@ IF(OpenIGTLinkIO_DIR)
   SET (PLUS_OpenIGTLinkIO_DIR "${OpenIGTLinkIO_DIR}" CACHE INTERNAL "Path to store OpenIGTLinkIO binaries")
 ELSE()
   # OpenIGTLinkIO has not been built yet, so download and build it as an external project
-  MESSAGE(STATUS "Downloading OpenIGTLinkIO from ${GIT_PROTOCOL}://github.com/IGSIO/OpenIGTLinkIO.git")
+  SetGitRepositoryTag(
+    OpenIGTLinkIO
+    "${GIT_PROTOCOL}://github.com/IGSIO/OpenIGTLinkIO.git"
+    "master"
+    )
 
   SET (PLUS_OpenIGTLinkIO_SRC_DIR "${CMAKE_BINARY_DIR}/Deps/OpenIGTLinkIO")
   SET (PLUS_OpenIGTLinkIO_DIR "${CMAKE_BINARY_DIR}/Deps/OpenIGTLinkIO-bin" CACHE INTERNAL "Path to store OpenIGTLinkIO binaries")
@@ -37,8 +41,8 @@ ELSE()
     SOURCE_DIR "${PLUS_OpenIGTLinkIO_SRC_DIR}"
     BINARY_DIR "${PLUS_OpenIGTLinkIO_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/IGSIO/OpenIGTLinkIO.git"
-    GIT_TAG "master"
+    GIT_REPOSITORY ${OpenIGTLinkIO_GIT_REPOSITORY}
+    GIT_TAG ${OpenIGTLinkIO_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS 
       ${ep_common_args}

--- a/SuperBuild/External_OvrvisionPro.cmake
+++ b/SuperBuild/External_OvrvisionPro.cmake
@@ -32,10 +32,6 @@ ELSE()
     SET(OvrvisionPro_DEPENDENCIES)
   ENDIF()
 
-  SET(OvrvisionPro_REPOSITORY https://github.com/PLUSToolkit/OvrvisionProCMake.git)
-
-  MESSAGE(STATUS "Downloading OvrvisionPro SDK from: ${OvrvisionPro_REPOSITORY}")
-
   # --------------------------------------------------------------------------
   # OvrvisionPro SDK
   SET (PLUS_OvrvisionPro_src_DIR ${CMAKE_BINARY_DIR}/Deps/OvrvisionPro CACHE INTERNAL "Path to store OvrvisionPro contents.")
@@ -54,14 +50,20 @@ ELSE()
     # Linux?
   ENDIF()
 
+  SetGitRepositoryTag(
+    OvrvisionPro
+    "${GIT_PROTOCOL}://github.com/PLUSToolkit/OvrvisionProCMake.git"
+    "master"
+    )
+
   ExternalProject_Add( OvrvisionPro
     PREFIX ${PLUS_OvrvisionPro_prefix_DIR}
     "${PLUSBUILD_EXTERNAL_PROJECT_CUSTOM_COMMANDS}"
     SOURCE_DIR "${PLUS_OvrvisionPro_src_DIR}"
     BINARY_DIR "${PLUS_OvrvisionPro_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY ${OvrvisionPro_REPOSITORY}
-    GIT_TAG master
+    GIT_REPOSITORY ${OvrvisionPro_GIT_REPOSITORY}
+    GIT_TAG ${OvrvisionPro_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS
       ${ep_common_args}

--- a/SuperBuild/External_PlusApp.cmake
+++ b/SuperBuild/External_PlusApp.cmake
@@ -8,6 +8,13 @@ IF(BUILDNAME)
   )
 ENDIF()
 
+IF(NOT DEFINED(PLUSAPP_GIT_REPOSITORY))
+  SET(PLUSAPP_GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusApp.git" CACHE STRING "Set PlusApp desired git url")
+ENDIF()
+IF(NOT DEFINED(PLUSAPP_GIT_REVISION))
+  SET(PLUSAPP_GIT_REVISION "master" CACHE STRING "Set PlusApp desired git hash (master means latest)")
+ENDIF()
+
 SET (PLUS_PLUSAPP_DIR ${CMAKE_BINARY_DIR}/PlusApp CACHE INTERNAL "Path to store PlusApp contents.")
 SET (PLUSAPP_DIR ${CMAKE_BINARY_DIR}/PlusApp-bin CACHE PATH "The directory containing PlusApp binaries" FORCE)                
 ExternalProject_Add(PlusApp
@@ -15,7 +22,7 @@ ExternalProject_Add(PlusApp
   SOURCE_DIR "${PLUS_PLUSAPP_DIR}" 
   BINARY_DIR "${PLUSAPP_DIR}"
   #--Download step--------------
-  GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusApp.git"
+  GIT_REPOSITORY ${PLUSAPP_GIT_REPOSITORY}
   GIT_TAG ${PLUSAPP_GIT_REVISION}
   #--Configure step-------------
   CMAKE_ARGS 

--- a/SuperBuild/External_PlusLib.cmake
+++ b/SuperBuild/External_PlusLib.cmake
@@ -298,6 +298,13 @@ IF(BUILDNAME)
     )
 ENDIF(BUILDNAME)
 
+IF(NOT DEFINED(PLUSLIB_GIT_REPOSITORY))
+  SET(PLUSLIB_GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusLib.git" CACHE STRING "Set PlusLib desired git url")
+ENDIF()
+IF(NOT DEFINED(PLUSLIB_GIT_REVISION))
+  SET(PLUSLIB_GIT_REVISION "master" CACHE STRING "Set PlusLib desired git hash (master means latest)")
+ENDIF()
+
 # --------------------------------------------------------------------------
 # PlusLib
 SET (PLUS_PLUSLIB_DIR ${CMAKE_BINARY_DIR}/PlusLib CACHE INTERNAL "Path to store PlusLib contents.")
@@ -307,7 +314,7 @@ ExternalProject_Add(PlusLib
   SOURCE_DIR "${PLUS_PLUSLIB_DIR}"
   BINARY_DIR "${PLUSLIB_DIR}"
   #--Download step--------------
-  GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusLib.git"
+  GIT_REPOSITORY ${PLUSLIB_GIT_REPOSITORY}
   GIT_TAG ${PLUSLIB_GIT_REVISION}
   #--Configure step-------------
   CMAKE_ARGS

--- a/SuperBuild/External_PlusLibData.cmake
+++ b/SuperBuild/External_PlusLibData.cmake
@@ -1,9 +1,10 @@
 #--------------------------------------------------------------------------
 # PlusLibData
-IF( "${PLUSBUILD_PLUSLIBDATA_GIT_REVISION}" STREQUAL "master" )
-  SET(PLUSLIBDATA_GIT_TAG)
-ELSE()
-  SET(PLUSLIBDATA_GIT_TAG "GIT_TAG ${PLUSBUILD_PLUSLIBDATA_GIT_REVISION}")
+IF(NOT DEFINED(PLUSBUILD_PLUSLIBDATA_GIT_REPOSITORY))
+  SET(PLUSBUILD_PLUSLIBDATA_GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusLibData.git" CACHE STRING "Set PlusLibData desired git url.")
+ENDIF()
+IF(NOT DEFINED(PLUSBUILD_PLUSLIBDATA_GIT_REVISION))
+  SET(PLUSBUILD_PLUSLIBDATA_GIT_REVISION "master" CACHE STRING "Set PlusLibData desired git hash (master means latest).")
 ENDIF()
 
 SET (PLUS_PLUSLIBDATA_DIR ${CMAKE_BINARY_DIR}/PlusLibData CACHE INTERNAL "Path to store PlusLib contents.")
@@ -11,8 +12,8 @@ ExternalProject_Add(PlusLibData
   "${PLUSBUILD_EXTERNAL_PROJECT_CUSTOM_COMMANDS}"
   SOURCE_DIR "${PLUS_PLUSLIBDATA_DIR}"
   #--Download step--------------
-  GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusLibData.git"
-  ${PLUSLIBDATA_GIT_TAG}
+  GIT_REPOSITORY ${PLUSBUILD_PLUSLIBDATA_GIT_REPOSITORY}
+  GIT_TAG ${PLUSBUILD_PLUSLIBDATA_GIT_REVISION}
   #--Configure step-------------
   CONFIGURE_COMMAND ""
   #--Build step-----------------

--- a/SuperBuild/External_PlusModelCatalog.cmake
+++ b/SuperBuild/External_PlusModelCatalog.cmake
@@ -1,13 +1,20 @@
 # --------------------------------------------------------------------------
 # PlusModelCatalog
 
+SetGitRepositoryTag(
+  PlusModelCatalog
+  "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusModelCatalog.git"
+  "master"
+  )
+
 SET (PLUS_PLUSMODELCATALOG_DIR ${CMAKE_BINARY_DIR}/PlusModelCatalog CACHE INTERNAL "Path to store Plus Model Catalog.")
 ExternalProject_Add(PlusModelCatalog
   "${PLUSBUILD_EXTERNAL_PROJECT_CUSTOM_COMMANDS}"
   SOURCE_DIR "${PLUS_PLUSMODELCATALOG_DIR}" 
   BINARY_DIR "PlusModelCatalog-bin"
   #--Download step--------------
-  GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PlusToolkit/PlusModelCatalog.git"
+  GIT_REPOSITORY ${PlusModelCatalog_GIT_REPOSITORY}
+  GIT_TAG ${PlusModelCatalog_GIT_TAG}
   #--Configure step-------------
   CMAKE_ARGS 
     ${ep_common_args}

--- a/SuperBuild/External_Tesseract.cmake
+++ b/SuperBuild/External_Tesseract.cmake
@@ -4,6 +4,12 @@ SET(tesseract_ROOT_DIR ${CMAKE_BINARY_DIR}/Deps)
 
 # --------------------------------------------------------------------------
 # leptonica
+SetGitRepositoryTag(
+  leptonica
+  "${GIT_PROTOCOL}://github.com/PLUSToolkit/leptonica.git"
+  "master"
+  )
+
 IF(leptonica_DIR)
   FIND_PACKAGE(leptonica REQUIRED NO_MODULE)
   
@@ -18,8 +24,8 @@ ELSE()
     SOURCE_DIR "${PLUS_leptonica_src_DIR}"
     BINARY_DIR "${PLUS_leptonica_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PLUSToolkit/leptonica.git"
-    GIT_TAG master
+    GIT_REPOSITORY ${leptonica_GIT_REPOSITORY}
+    GIT_TAG ${leptonica_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS
         ${ep_common_args}
@@ -37,6 +43,12 @@ ENDIF()
 
 # --------------------------------------------------------------------------
 # tessdata
+SetGitRepositoryTag(
+  tessdata
+  "${GIT_PROTOCOL}://github.com/PLUSToolkit/tessdata.git"
+  "master"
+  )
+
 IF(tessdata_DIR)
   IF(NOT EXISTS ${tessdata_DIR})
     MESSAGE(FATAL_ERROR "Folder specified by tessdata_DIR does not exist.")
@@ -52,8 +64,8 @@ ELSE()
     SOURCE_DIR "${PLUS_tessdata_src_DIR}"
     BINARY_DIR "${PLUS_tessdata_src_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PLUSToolkit/tessdata.git"
-    GIT_TAG master
+    GIT_REPOSITORY ${tessdata_GIT_REPOSITORY}
+    GIT_TAG ${tessdata_GIT_TAG}
     #--Configure step-------------
     CONFIGURE_COMMAND ""
     #--Build step-----------------
@@ -111,7 +123,12 @@ IF(tesseract_DIR)
   
   SET (PLUS_tesseract_DIR ${tesseract_DIR} CACHE INTERNAL "Path to store tesseract binaries")
 ELSE()
-  MESSAGE("Downloading tesseract from ${GIT_PROTOCOL}://github.com/PLUSToolkit/tesseract-ocr-cmake.git")
+
+  SetGitRepositoryTag(
+    tesseract
+    "${GIT_PROTOCOL}://github.com/PLUSToolkit/tesseract-ocr-cmake.git"
+    "21855d0568a9253dede4e223aae71c0249b90438"
+    )
 
   SET (PLUS_tesseract_src_DIR ${tesseract_ROOT_DIR}/tesseract CACHE INTERNAL "Path to store tesseract contents.")
   SET (PLUS_tesseract_prefix_DIR ${tesseract_ROOT_DIR}/tesseract-prefix CACHE INTERNAL "Path to store tesseract prefix data.")
@@ -122,8 +139,8 @@ ELSE()
     SOURCE_DIR "${PLUS_tesseract_src_DIR}"
     BINARY_DIR "${PLUS_tesseract_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY "${GIT_PROTOCOL}://github.com/PLUSToolkit/tesseract-ocr-cmake.git"
-    GIT_TAG 21855d0568a9253dede4e223aae71c0249b90438
+    GIT_REPOSITORY ${tesseract_GIT_REPOSITORY}
+    GIT_TAG ${tesseract_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS
       ${ep_common_args}

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -53,11 +53,6 @@ IF(VTK_DIR)
   SET(VTK_BUILD_DEPENDENCY_TARGET CACHE INTERNAL "The name of the target to list as a dependency to ensure build order correctness.")
 ELSE()
   # VTK has not been built yet, so download and build it as an external project
-  SET(VTK_GIT_PROTOCOL https)
-
-  SET(VTK_GIT_REPOSITORY "gitlab.kitware.com/vtk/vtk.git")
-  SET(VTK_GIT_TAG "v7.1.0")
-  SET(VTK_GIT_PROTOCOL https)
 
   SET(VTK_VERSION_SPECIFIC_ARGS)
   IF(PLUSBUILD_BUILD_PLUSAPP)
@@ -80,8 +75,12 @@ ELSE()
   IF(MSVC)
     LIST(APPEND VTK_VERSION_SPECIFIC_ARGS -DCMAKE_CXX_MP_FLAG:BOOL=ON)
   ENDIF()
-  
-  MESSAGE(STATUS "Downloading VTK ${VTK_GIT_TAG} from: ${VTK_GIT_PROTOCOL}://${VTK_GIT_REPOSITORY}")
+
+  SetGitRepositoryTag(
+    VTK
+    "${GIT_PROTOCOL}://gitlab.kitware.com/vtk/vtk.git"
+    "v7.1.0"
+    )
 
   SET (PLUS_VTK_SRC_DIR "${CMAKE_BINARY_DIR}/Deps/vtk")
   SET (PLUS_VTK_DIR "${CMAKE_BINARY_DIR}/Deps/vtk-bin" CACHE INTERNAL "Path to store vtk binaries")
@@ -92,7 +91,7 @@ ELSE()
     SOURCE_DIR "${PLUS_VTK_SRC_DIR}"
     BINARY_DIR "${PLUS_VTK_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY "${VTK_GIT_PROTOCOL}://${VTK_GIT_REPOSITORY}"
+    GIT_REPOSITORY ${VTK_GIT_REPOSITORY}
     GIT_TAG ${VTK_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS 

--- a/SuperBuild/External_aruco.cmake
+++ b/SuperBuild/External_aruco.cmake
@@ -35,9 +35,11 @@ IF(aruco_DIR)
   SET (PLUS_aruco_DIR ${aruco_DIR} CACHE INTERNAL "Path to store aruco binaries")
 ELSE()
   # aruco has not been built yet, so download and build it as an external project
-  SET(aruco_GIT_REPOSITORY https://github.com/PlusToolkit/aruco.git)
-
-  MESSAGE(STATUS "Downloading aruco from: ${aruco_GIT_REPOSITORY}")
+  SetGitRepositoryTag(
+    aruco
+    "${GIT_PROTOCOL}://github.com/PlusToolkit/aruco.git"
+    "master"
+    )
 
   SET (PLUS_aruco_src_DIR ${CMAKE_BINARY_DIR}/Deps/aruco CACHE INTERNAL "Path to store aruco contents")
   SET (PLUS_aruco_prefix_DIR ${CMAKE_BINARY_DIR}/Deps/aruco-prefix CACHE INTERNAL "Path to store aruco prefix data.")
@@ -50,6 +52,7 @@ ELSE()
     BINARY_DIR "${PLUS_aruco_DIR}"
     #--Download step--------------
     GIT_REPOSITORY ${aruco_GIT_REPOSITORY}
+    GIT_TAG ${aruco_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS
       ${ep_common_args}

--- a/SuperBuild/External_ndicapi.cmake
+++ b/SuperBuild/External_ndicapi.cmake
@@ -29,9 +29,11 @@ IF(ndicapi_DIR)
 
   SET(PLUS_ndicapi_DIR ${ndicapi_DIR} CACHE INTERNAL "Path to store ndicapi binaries")
 ELSE()
-  SET(ndicapi_REPOSITORY https://github.com/PlusToolkit/ndicapi.git)
-
-  MESSAGE(STATUS "Downloading ndicapi from: ${ndicapi_REPOSITORY}")
+  SetGitRepositoryTag(
+    ndicapi
+    "${GIT_PROTOCOL}://github.com/PlusToolkit/ndicapi.git"
+    "master"
+    )
 
   # --------------------------------------------------------------------------
   # OvrvisionPro SDK
@@ -45,8 +47,8 @@ ELSE()
     SOURCE_DIR "${PLUS_ndicapi_src_DIR}"
     BINARY_DIR "${PLUS_ndicapi_DIR}"
     #--Download step--------------
-    GIT_REPOSITORY ${ndicapi_REPOSITORY}
-    GIT_TAG master
+    GIT_REPOSITORY ${ndicapi_GIT_REPOSITORY}
+    GIT_TAG ${ndicapi_GIT_TAG}
     #--Configure step-------------
     CMAKE_ARGS
       ${ep_common_args}


### PR DESCRIPTION
Edit:
Collect the Git info for external repositories so that they are more homogeneous.
In each External_.cmake file, there is a macro call that creates project_GIT_REPOSITORY and project_GIT_TAG variables, as well as displaying a download message for the repo.

Original Message: Allow PlusLibData to use additional git revisions other than master.
Currently, PlusLibData fails to checkout any branches other than the master.
If a different branch is specified, git checkout will fail, returning a build error.