### PR TITLE
Make Plus-2.6 compile on Ubuntu 16.04 with NDI support

### DIFF
--- a/SuperBuild/External_ndicapi.cmake
+++ b/SuperBuild/External_ndicapi.cmake
@@ -32,7 +32,7 @@ ELSE()
   SetGitRepositoryTag(
     ndicapi
     "${GIT_PROTOCOL}://github.com/PlusToolkit/ndicapi.git"
-    "f1bf6d55f8fa61105dc219ab09ee706cfecc0564"
+    "c79aec212c0793c3cb0cfb3acd6435ff2ac4cdc1"
     )
 
   # --------------------------------------------------------------------------


### PR DESCRIPTION
Ubuntu 16.04 comes with CMake 3.5.1. By changing the sha of the ndicapi repo to one commit later allows us to compile Plus-2.6 on Ubuntu 16.04 with NDI support.