### PR TITLE
Update for the Seek Thermal Camera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ IF(Git_FOUND)
 ENDIF()
 SET(_x86env "ProgramFiles(x86)")
 FIND_PROGRAM(BASH_EXECUTABLE bash
-  HINTS 
+  HINTS
     ${_git_directory}
     $ENV{ProgramFiles}/Git/bin
     $ENV{${_x86env}}/Git/bin
@@ -206,7 +206,7 @@ OPTION(PLUS_USE_WINPROBE_VIDEO "Provide support WinProbe ultrasound systems" OFF
 OPTION(PLUS_USE_INTERSON_VIDEO "Provide support for the Interson USB ultrasound probes" OFF)
 OPTION(PLUS_USE_INTERSONSDKCXX_VIDEO "Provide support for the Interson SDK 1.X with C++ Wrapper USB ultrasound probes" OFF)
 OPTION(PLUS_USE_TELEMED_VIDEO "Provide support for the Telemed ultrasound probes" OFF)
-OPTION(PLUS_USE_AGILENT "Provide support for the Agilent digitizer device" OFF) 
+OPTION(PLUS_USE_AGILENT "Provide support for the Agilent digitizer device" OFF)
 IF(PLUS_USE_TELEMED_VIDEO)
   OPTION(PLUS_TEST_TELEMED "Enable testing of acquisition from Telemed ultrasound systems. Enable this only if a Telemed device is connected to this computer. " OFF)
 ENDIF (PLUS_USE_TELEMED_VIDEO)
@@ -485,6 +485,7 @@ ENDIF()
 
 # Infrared Thermal Seek camera
 IF(PLUS_USE_INFRARED_SEEK_CAM)
+  INCLUDE(SuperBuild/External_libusb.cmake)
   INCLUDE(SuperBuild/External_InfraredSeekCam.cmake)
 ENDIF()
 

--- a/SuperBuild/External_InfraredSeekCam.cmake
+++ b/SuperBuild/External_InfraredSeekCam.cmake
@@ -45,6 +45,6 @@ ELSE()
     BUILD_ALWAYS 1
     #--Install step-----------------
     INSTALL_COMMAND ""
-    DEPENDS LibUSB ${SeekCameraLib_DEPENDENCIES}
+    DEPENDS LibUSB OpenCV ${SeekCameraLib_DEPENDENCIES}
    )
 ENDIF()

--- a/SuperBuild/External_InfraredSeekCam.cmake
+++ b/SuperBuild/External_InfraredSeekCam.cmake
@@ -11,7 +11,7 @@ ELSE()
   # SeekCameraLib has not been built yet, so download and build it as an external project
   SetGitRepositoryTag(
     SeekCameraLib
-    "${GIT_PROTOCOL}://github.com/medtec4susdev/libseek-thermal.git"
+    "${GIT_PROTOCOL}://github.com/Ediolot/libseek-thermal.git"
     master
     )
 
@@ -29,12 +29,16 @@ ELSE()
     #--Configure step-------------
     CMAKE_ARGS
       ${ep_common_args}
+      -DLibUSB_ROOT_DIR:PATH=${LibUSB_ROOT_DIR}
+      -DOpenCV_DIR:PATH=${PLUS_OpenCV_DIR}
+      -DBUILD_EXAMPLES:BOOL=FALSE
+      -DINSTALL_DLL:BOOL=FALSE
+      -DWITH_ADDRESS_SANITIZER:BOOL=FALSE
+      -DWITH_DEBUG_VERBOSITY:BOOL=FALSE
       -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
       -DCMAKE_LIBRARY_OUTPUT_DIRECTORY:PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
       -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:PATH=${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
       -DBUILD_SHARED_LIBS:BOOL=${PLUSBUILD_BUILD_SHARED_LIBS}
-      -DOpenCV_DIR:PATH=${PLUS_OpenCV_DIR}
-      -DLibUSB_ROOT_DIR:PATH=${LibUSB_ROOT_DIR}
       -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
       -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
     #--Build step-----------------

--- a/SuperBuild/External_InfraredSeekCam.cmake
+++ b/SuperBuild/External_InfraredSeekCam.cmake
@@ -11,7 +11,7 @@ ELSE()
   # SeekCameraLib has not been built yet, so download and build it as an external project
   SetGitRepositoryTag(
     SeekCameraLib
-    "${GIT_PROTOCOL}://github.com/Ediolot/libseek-thermal.git"
+    "${GIT_PROTOCOL}://github.com/medtec4susdev/libseek-thermal.git"
     master
     )
 
@@ -45,6 +45,6 @@ ELSE()
     BUILD_ALWAYS 1
     #--Install step-----------------
     INSTALL_COMMAND ""
-    DEPENDS ${SeekCameraLib_DEPENDENCIES}
+    DEPENDS LibUSB ${SeekCameraLib_DEPENDENCIES}
    )
 ENDIF()

--- a/SuperBuild/External_PlusLib.cmake
+++ b/SuperBuild/External_PlusLib.cmake
@@ -344,6 +344,8 @@ ENDIF()
 # PlusLib
 SET (PLUS_PLUSLIB_DIR ${CMAKE_BINARY_DIR}/PlusLib CACHE INTERNAL "Path to store PlusLib contents.")
 SET (PLUSLIB_DIR ${CMAKE_BINARY_DIR}/PlusLib-bin CACHE PATH "The directory containing PlusLib binaries" FORCE)
+
+# CONFIGURE AND BUILD
 ExternalProject_Add(PlusLib
   "${PLUSBUILD_EXTERNAL_PROJECT_CUSTOM_COMMANDS}"
   SOURCE_DIR "${PLUS_PLUSLIB_DIR}"

--- a/SuperBuild/External_PlusLib.cmake
+++ b/SuperBuild/External_PlusLib.cmake
@@ -344,8 +344,6 @@ ENDIF()
 # PlusLib
 SET (PLUS_PLUSLIB_DIR ${CMAKE_BINARY_DIR}/PlusLib CACHE INTERNAL "Path to store PlusLib contents.")
 SET (PLUSLIB_DIR ${CMAKE_BINARY_DIR}/PlusLib-bin CACHE PATH "The directory containing PlusLib binaries" FORCE)
-
-# CONFIGURE AND BUILD
 ExternalProject_Add(PlusLib
   "${PLUSBUILD_EXTERNAL_PROJECT_CUSTOM_COMMANDS}"
   SOURCE_DIR "${PLUS_PLUSLIB_DIR}"

--- a/SuperBuild/External_libusb.cmake
+++ b/SuperBuild/External_libusb.cmake
@@ -1,0 +1,48 @@
+SET(LibUSB_WinURL "https://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-1.0.22/libusb-1.0.22.7z/download")
+
+# Download libusb if windows
+# In Linux install with sudo apt-get install libusb-1.0-0-dev
+IF (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+
+  SET(DEPS_DIR        ${CMAKE_BINARY_DIR}/Deps)
+  SET(LibUSB_SRC      ${DEPS_DIR}/libusb)
+  SET(LibUSB_STAMP    ${DEPS_DIR}/libusb-stamp)
+  SET(LibUSB_PREFIX   ${DEPS_DIR}/libusb-prefix)
+  SET(LibUSB_ROOT_DIR ${LibUSB_SRC})
+
+  SET(LibUSB_INCLUDE_DIRS ${LibUSB_SRC}/include)
+  SET(LibUSB_INCLUDES     ${LibUSB_SRC}/include)
+  SET(LIBUSB_INCLUDE_DIR  ${LibUSB_SRC}/include)
+
+  IF(MSVC OR ${CMAKE_GENERATOR} MATCHES "Xcode")
+    SET(LibUSB_LIBRARY_DIR  ${LibUSB_SRC}/MS32/dll)
+  ELSE ()
+    SET(LibUSB_LIBRARY_DIR  ${LibUSB_SRC}/MinGW32/dll)
+  ENDIF ()
+  SET(LIBUSB_LIBRARY ${LibUSB_LIBRARY_DIR}/libusb-1.0.dll ${LibUSB_LIBRARY_DIR}/libusb-1.0.lib)
+
+  INCLUDE(ExternalProject)
+  ExternalProject_Add(LibUSB
+    PREFIX     ${LibUSB_PREFIX}
+    SOURCE_DIR ${LibUSB_SRC}
+    BINARY_DIR ${LibUSB_SRC} # No build step
+    STAMP_DIR  ${LibUSB_STAMP}
+    #--Download step--------------
+    DOWNLOAD_NAME libusb.7z
+    DOWNLOAD_DIR  ${LibUSB_SRC}
+    URL           ${LibUSB_WinURL}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    )
+
+ELSE ()
+
+  # Copied from original repository https://github.com/maartenvds/libseek-thermal
+  SET(LibUSB_INCLUDE_DIRS /usr/include/LibUSB-1.0)
+  SET(LibUSB_INCLUDES     /usr/include/LibUSB-1.0)
+  SET(LIBUSB_INCLUDE_DIR  /usr/include/LibUSB-1.0)
+  SET(LibUSB_LIBS    -lusb-1.0)
+  SET(LIBUSB_LIBRARY -lusb-1.0)
+
+ENDIF ()

--- a/SuperBuild/External_libusb.cmake
+++ b/SuperBuild/External_libusb.cmake
@@ -10,17 +10,20 @@ IF (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   SET(LibUSB_PREFIX   ${DEPS_DIR}/libusb-prefix)
   SET(LibUSB_ROOT_DIR ${LibUSB_SRC})
 
+  # PATHS WHERE WE KNOW THE HEADERS WILL BE LOCATED
   SET(LibUSB_INCLUDE_DIRS ${LibUSB_SRC}/include)
   SET(LibUSB_INCLUDES     ${LibUSB_SRC}/include)
   SET(LIBUSB_INCLUDE_DIR  ${LibUSB_SRC}/include)
 
+  # PATH WHERE WE KNOW THE LIBRARY WILL BE LOCATED
   IF(MSVC OR ${CMAKE_GENERATOR} MATCHES "Xcode")
     SET(LibUSB_LIBRARY_DIR  ${LibUSB_SRC}/MS32/dll)
   ELSE ()
     SET(LibUSB_LIBRARY_DIR  ${LibUSB_SRC}/MinGW32/dll)
   ENDIF ()
-  SET(LIBUSB_LIBRARY ${LibUSB_LIBRARY_DIR}/libusb-1.0.dll ${LibUSB_LIBRARY_DIR}/libusb-1.0.lib)
+  SET(LIBUSB_LIBRARY ${LibUSB_LIBRARY_DIR}/libusb-1.0.lib)
 
+  # DOWNLOAD LIBUSB
   INCLUDE(ExternalProject)
   ExternalProject_Add(LibUSB
     PREFIX     ${LibUSB_PREFIX}
@@ -38,6 +41,7 @@ IF (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 
 ELSE ()
 
+  # LIBUSB LOCATION IF INSTALLED IN LINUX
   # Copied from original repository https://github.com/maartenvds/libseek-thermal
   SET(LibUSB_INCLUDE_DIRS /usr/include/LibUSB-1.0)
   SET(LibUSB_INCLUDES     /usr/include/LibUSB-1.0)

--- a/SuperBuild/External_libusb.cmake
+++ b/SuperBuild/External_libusb.cmake
@@ -1,7 +1,7 @@
 SET(LibUSB_WinURL "https://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-1.0.22/libusb-1.0.22.7z/download")
 
 # Download libusb if windows
-# In Linux install with sudo apt-get install libusb-1.0-0-dev
+# In Linux install required with sudo apt-get install libusb-1.0-0-dev
 IF (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 
   SET(DEPS_DIR        ${CMAKE_BINARY_DIR}/Deps)
@@ -10,12 +10,10 @@ IF (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   SET(LibUSB_PREFIX   ${DEPS_DIR}/libusb-prefix)
   SET(LibUSB_ROOT_DIR ${LibUSB_SRC})
 
-  # PATHS WHERE WE KNOW THE HEADERS WILL BE LOCATED
   SET(LibUSB_INCLUDE_DIRS ${LibUSB_SRC}/include)
   SET(LibUSB_INCLUDES     ${LibUSB_SRC}/include)
   SET(LIBUSB_INCLUDE_DIR  ${LibUSB_SRC}/include)
 
-  # PATH WHERE WE KNOW THE LIBRARY WILL BE LOCATED
   IF(MSVC OR ${CMAKE_GENERATOR} MATCHES "Xcode")
     SET(LibUSB_LIBRARY_DIR  ${LibUSB_SRC}/MS32/dll)
   ELSE ()
@@ -23,7 +21,6 @@ IF (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   ENDIF ()
   SET(LIBUSB_LIBRARY ${LibUSB_LIBRARY_DIR}/libusb-1.0.lib)
 
-  # DOWNLOAD LIBUSB
   INCLUDE(ExternalProject)
   ExternalProject_Add(LibUSB
     PREFIX     ${LibUSB_PREFIX}
@@ -41,7 +38,10 @@ IF (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 
 ELSE ()
 
-  # LIBUSB LOCATION IF INSTALLED IN LINUX
+  IF (NOT EXISTS "/usr/include/LibUSB-1.0")
+    MESSAGE(FATAL_ERROR "LibUSB required but not found at /usr/include/LibUSB-1.0 Please install LibUSB.")
+  ENDIF ()
+
   # Copied from original repository https://github.com/maartenvds/libseek-thermal
   SET(LibUSB_INCLUDE_DIRS /usr/include/LibUSB-1.0)
   SET(LibUSB_INCLUDES     /usr/include/LibUSB-1.0)


### PR DESCRIPTION
Update for the configuration of the new Seek Thermal Camera module. Now works on windows and can be configured to use a flat and bias images for calibration, as well as temperature values.

The Seek Thermal Camera build depends on libusb, so a libusb module has been added to download the binaries in case we are building on Windows. 