### PR TITLE
re #544 Update ITK to 5.0.0

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -12,7 +12,7 @@ ELSE()
 
   SET (PLUS_ITK_VERSION_MAJOR 5)
   SET (PLUS_ITK_VERSION_MINOR 0)
-  SET (PLUS_ITK_VERSION_PATCH "rc02")
+  SET (PLUS_ITK_VERSION_PATCH 0)
   # ITK has not been built yet, so download and build it as an external project
   SetGitRepositoryTag(
     itk


### PR DESCRIPTION
ITK v5.0.0 has been officially released.  This updates the usage of rc02 to the official 5.0.0 release.
See https://discourse.itk.org/t/itk-5-0-0-has-been-released/1931