### PR TITLE
BUILD: Fix issues when building ClariusOEM using external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,15 @@ IF("${CMAKE_CXX_STANDARD}" LESS "${_minimum_cxx_standard}")
 ENDIF()
 SET(CMAKE_CXX_STANDARD_REQUIRED ON CACHE STRING "C++ standard required")
 
+IF (PLUS_USE_CLARIUS_OEM)
+  # ClariusOEM device uses C++/WinRT interface for managing Bluetooth LE connection to the probe, this requires C++ 17
+  SET(_minimum_cxx_standard "17")
+  IF("${CMAKE_CXX_STANDARD}" LESS "${_minimum_cxx_standard}")
+    MESSAGE("The C++17 standard is required for the Clarius OEM device, updating CMAKE_CXX_STANDARD to 17")
+    SET(CMAKE_CXX_STANDARD "${_minimum_cxx_standard}" CACHE STRING "C++ standard" FORCE)
+  ENDIF()
+ENDIF()
+
 IF(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
   cmake_policy(SET CMP0097 NEW) # Empty string in git submodules means no submodules, cmake 3.16+
@@ -455,10 +464,6 @@ IF(PLUS_USE_OPTITRACK)
   LIST(APPEND PLUSBUILD_QT_COMPONENTS Multimedia)
 ENDIF()
 
-IF(PLUS_USE_CLARIUS_OEM)
-  LIST(APPEND PLUSBUILD_QT_COMPONENTS Bluetooth)
-ENDIF()
-
 IF(PLUSBUILD_BUILD_PLUSAPP OR PLUSBUILD_BUILD_PLUSLIB_WIDGETS)
   FIND_PACKAGE(Qt5 COMPONENTS ${PLUSBUILD_QT_COMPONENTS} QUIET)
 
@@ -771,13 +776,6 @@ IF(PLUS_USE_CLARIUS_OEM)
   # Check Win32, Clarius OEM is only supported on Windows
   IF(NOT WIN32)
     message(FATAL_ERROR "Clarius OEM device is only available on Windows. Please use Windows to compile PLUS, or set PLUS_USE_CLARIUS_OEM to OFF.")
-  ENDIF()
-
-  # ClariusOEM device uses C++/WinRT interface for managing Bluetooth LE connection to the probe, this requires C++ 17
-  SET(_minimum_cxx_standard "17")
-  IF("${CMAKE_CXX_STANDARD}" LESS "${_minimum_cxx_standard}")
-    MESSAGE("The C++17 standard is required for the Clarius OEM device, updating CMAKE_CXX_STANDARD to 17")
-    SET(CMAKE_CXX_STANDARD "${_minimum_cxx_standard}" CACHE STRING "C++ standard" FORCE)
   ENDIF()
 
   INCLUDE(Superbuild/External_ClariusOEM.cmake)

--- a/Modules/FindClariusOEM.cmake
+++ b/Modules/FindClariusOEM.cmake
@@ -17,8 +17,8 @@ IF(NOT DEFINED ClariusOEM_DIR)
   # path hints
   IF(WIN32)
     SET(ClariusOEM_PATH_HINTS
-      "../oem"
-      "../../oem"
+      "../oem/src"
+      "../../oem/src"
       )
   ELSE()
     MESSAGE(FATAL_ERROR "Clarius OEM SDK is currently only supported on Windows")

--- a/SuperBuild/External_ClariusOEM.cmake
+++ b/SuperBuild/External_ClariusOEM.cmake
@@ -1,4 +1,4 @@
-IF(ClariusOEM_DIR)
+IF(ClariusOEM_DIR AND NOT DEFINED ${SUPERBUILD_ClariusOEM})
   
   FIND_PACKAGE(ClariusOEM REQUIRED)
 
@@ -11,19 +11,23 @@ ELSE()
 
   # git clone of OEM interface
   
+  SET(SUPERBUILD_ClariusOEM ON CACHE BOOL "Should ClariusOEM be downloaded using ExternalProject")
+  MARK_AS_ADVANCED(SUPERBUILD_ClariusOEM)
+  
   SetGitRepositoryTag(
     ClariusOEM
     "${GIT_PROTOCOL}://github.com/clariusdev/oem.git"
     "v9.1.0"
     )
 
-  SET(ClariusOEM_DIR "${CMAKE_BINARY_DIR}/ClariusOEM" CACHE PATH "Path to Clarius OEM SDK")
-  SET(ClariusOEM_PREFIX_DIR "${ClariusOEM_DIR}-prefix")
+  SET(ClariusOEM_OUTER_SRC_DIR "${CMAKE_BINARY_DIR}/ClariusOEM")
+  SET(ClariusOEM_DIR "${ClariusOEM_OUTER_SRC_DIR}/src" CACHE PATH "Path to Clarius OEM SDK")
+  SET(ClariusOEM_PREFIX_DIR "${CMAKE_BINARY_DIR}/ClariusOEM-prefix")
 
   ExternalProject_Add(ClariusOEM
     ${PLUSBUILD_EXTERNAL_PROJECT_CUSTOM_COMMANDS}
     PREFIX ${ClariusOEM_PREFIX_DIR}
-    SOURCE_DIR ${ClariusOEM_DIR}
+    SOURCE_DIR ${ClariusOEM_OUTER_SRC_DIR}
     #--Download step--------------
     GIT_REPOSITORY ${ClariusOEM_GIT_REPOSITORY}
     GIT_TAG ${ClariusOEM_GIT_TAG}
@@ -31,7 +35,7 @@ ELSE()
     CONFIGURE_COMMAND ""
     #--Build step-----------------
     BUILD_COMMAND ""
-    #--Install step-----------------
+    #--Install step---------------
     INSTALL_COMMAND ""
     DEPENDS ""
     )
@@ -44,7 +48,7 @@ ELSE()
   ExternalProject_Add(ClariusOEM-Libs
     ${PLUSBUILD_EXTERNAL_PROJECT_CUSTOM_COMMANDS}
     PREFIX ${ClariusOEM_PREFIX_DIR}
-    SOURCE_DIR ${ClariusOEM_DIR}/src/lib
+    SOURCE_DIR ${ClariusOEM_DIR}/lib
     #--Download step--------------
     URL ${CLARIUS_OEM_PACKAGE_URL}
     URL_HASH SHA256=${CLARIUS_OEM_PACKAGE_SHA256}
@@ -52,7 +56,7 @@ ELSE()
     CONFIGURE_COMMAND ""
     #--Build step-----------------
     BUILD_COMMAND ""
-    #--Install step-----------------
+    #--Install step---------------
     INSTALL_COMMAND ""
     DEPENDS ClariusOEM
     )


### PR DESCRIPTION
- Move Clarius C++17 CMAKE_CXX_STANDARD check before setting of ep_common_args to ensure it's correctly set if project is only configured once
- Fix issue with re-configuring when building the ClariusOEM library using external project