### PR TITLE
ENH: Add support for Capistrano cSDK2023

### DIFF
--- a/Modules/FindCapistrano.cmake
+++ b/Modules/FindCapistrano.cmake
@@ -9,8 +9,8 @@
 # CAPISTRANO_LIBRARY_BMODE_NAME - Bmode filename in the lib dir
 # CAPISTRANO_BINARY_BMODE_NAME - Bmode filename in the bin dir
 
-SET(Capistrano_SDK_VERSION "cSDK2019.3" CACHE STRING "Which cSDK version to build Plus against")
-SET(_csdk_versions "cSDK2019.3" "cSDK2019.2" "cSDK2019" "cSDK2018" "cSDK2016" "cSDK2013")
+SET(Capistrano_SDK_VERSION "cSDK2023" CACHE STRING "Which cSDK version to build Plus against")
+SET(_csdk_versions "cSDK2023" "cSDK2019.3" "cSDK2019.2" "cSDK2019" "cSDK2018" "cSDK2016" "cSDK2013")
 set_property(CACHE Capistrano_SDK_VERSION PROPERTY STRINGS ${_csdk_versions})
 
 unset(Capistrano_INCLUDE_DIR CACHE)
@@ -20,7 +20,11 @@ unset(Capistrano_WIN32_BINARY_DIR CACHE)
 unset(Capistrano_WIN64_BINARY_DIR CACHE)
 
 SET(Capistrano_FIND_FILE "USBprobe")
-IF(Capistrano_SDK_VERSION STREQUAL "cSDK2019.3" OR Capistrano_SDK_VERSION STREQUAL "cSDK2019.2" OR Capistrano_SDK_VERSION STREQUAL "cSDK2019" OR Capistrano_SDK_VERSION STREQUAL "cSDK2018")
+IF(Capistrano_SDK_VERSION STREQUAL "cSDK2023" OR
+   Capistrano_SDK_VERSION STREQUAL "cSDK2019.3" OR
+   Capistrano_SDK_VERSION STREQUAL "cSDK2019.2" OR
+   Capistrano_SDK_VERSION STREQUAL "cSDK2019" OR
+   Capistrano_SDK_VERSION STREQUAL "cSDK2018")
   SET(Capistrano_WIN32_LIBRARY_FILENAME_SUFFIX "CLI")
   SET(Capistrano_WIN64_LIBRARY_FILENAME_SUFFIX "CLI64")
   SET(Capistrano_WIN32_BINARY_FILENAME_SUFFIX "CLI")
@@ -36,6 +40,8 @@ ENDIF()
 
 IF(Capistrano_SDK_ROOT)
   SET(Capistrano_PATH_HINTS ${Capistrano_SDK_ROOT})
+ELSEIF(Capistrano_SDK_VERSION STREQUAL "cSDK2023")
+  SET(Capistrano_PATH_HINTS "c:/cSDK2023/cView2023")
 else()
   SET(Capistrano_PATH_HINTS "c:/${Capistrano_SDK_VERSION}")
 ENDIF()
@@ -61,6 +67,7 @@ FIND_PATH(Capistrano_WIN64_LIBRARY_DIR ${Capistrano_FIND_FILE}${Capistrano_WIN64
 FIND_PATH(Capistrano_WIN32_BINARY_DIR ${Capistrano_FIND_FILE}${Capistrano_WIN32_BINARY_FILENAME_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}
   PATH_SUFFIXES
     "bin"
+    "dll"
   DOC "Path to Capistrano 32-bit binary directory (contains 32-bit ${Capistrano_FIND_FILE}${Capistrano_WIN32_BINARY_FILENAME_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})"
   PATHS ${Capistrano_PATH_HINTS}
   NO_DEFAULT_PATH # avoid finding installed DLLs in the system folders
@@ -68,6 +75,7 @@ FIND_PATH(Capistrano_WIN32_BINARY_DIR ${Capistrano_FIND_FILE}${Capistrano_WIN32_
 FIND_PATH(Capistrano_WIN64_BINARY_DIR ${Capistrano_FIND_FILE}${Capistrano_WIN64_BINARY_FILENAME_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}
   PATH_SUFFIXES
     "bin/x64"
+    "dll"
   DOC "Path to Capistrano 64-bit binary directory (contains 64-bit ${Capistrano_FIND_FILE}${Capistrano_WIN64_BINARY_FILENAME_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})"
   PATHS ${Capistrano_PATH_HINTS}
   NO_DEFAULT_PATH # avoid finding installed DLLs in the system folders
@@ -91,7 +99,7 @@ endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 # handle the QUIETLY and REQUIRED arguments and set Capistrano_FOUND to TRUE if
 # all listed variables are TRUE
 INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Capistrano DEFAULT_MSG
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(CAPISTRANO DEFAULT_MSG
   Capistrano_LIBRARY_DIR
   Capistrano_INCLUDE_DIR
   Capistrano_BINARY_DIR
@@ -104,7 +112,11 @@ IF(CAPISTRANO_FOUND)
   SET(CAPISTRANO_BINARY_USBPROBE_NAME "USBprobe${Capistrano_BINARY_FILE_NAME_SUFFIX}")
   SET(CAPISTRANO_LIBRARY_USBPROBE_NAME "USBprobe${Capistrano_LIBRARY_FILE_NAME_SUFFIX}")
   SET(CAPISTRANO_BINARY_BMODE_NAME "BmodeUSB${Capistrano_BINARY_FILE_NAME_SUFFIX}")
-  IF(Capistrano_SDK_VERSION STREQUAL "cSDK2019.3" OR Capistrano_SDK_VERSION STREQUAL "cSDK2019.2" OR Capistrano_SDK_VERSION STREQUAL "cSDK2019" OR Capistrano_SDK_VERSION STREQUAL "cSDK2018")
+  IF(Capistrano_SDK_VERSION STREQUAL "cSDK2023" OR
+     Capistrano_SDK_VERSION STREQUAL "cSDK2019.3" OR
+     Capistrano_SDK_VERSION STREQUAL "cSDK2019.2" OR
+     Capistrano_SDK_VERSION STREQUAL "cSDK2019" OR
+     Capistrano_SDK_VERSION STREQUAL "cSDK2018")
     SET(CAPISTRANO_LIBRARY_BMODE_NAME "BmodeUSB${Capistrano_LIBRARY_FILE_NAME_SUFFIX}")
   ELSEIF(Capistrano_SDK_VERSION STREQUAL "cSDK2016" OR Capistrano_SDK_VERSION STREQUAL "cSDK2013")
     SET(CAPISTRANO_LIBRARY_BMODE_NAME "Bmode${Capistrano_LIBRARY_FILE_NAME_SUFFIX}")


### PR DESCRIPTION
This adds support for an updated Capistrano SDK (cSDK2023) that is provided by the supplier. One of the primary benefits of this new SDK is updated drivers (WinUSB based) instead of Jungo drivers 11.4.0 (for cSDK2016-2019) or 10.1.0 (for cSDK2013) which have posted CVEs for them:
- [CVE-2017-14075](https://nvd.nist.gov/vuln/detail/CVE-2017-14075)
- [CVE-2017-14153](https://nvd.nist.gov/vuln/detail/CVE-2017-14153) (quick [link](https://srcincite.io/blog/2017/09/06/sharks-in-the-pool-mixed-object-exploitation-in-the-windows-kernel-pool.html))
- [CVE-2017-14344](https://nvd.nist.gov/vuln/detail/CVE-2017-14344)

Corresponding PR:
https://github.com/PlusToolkit/PlusLib/pull/1104