### PR TITLE
Add build instructions for Ubuntu 24.04 LTS

### DIFF
--- a/Docs/BuildInstructionsLinux.md
+++ b/Docs/BuildInstructionsLinux.md
@@ -1,3 +1,31 @@
+Ubuntu 24.04 LTS
+================
+
+PlusBuild project contains a CMake project that builds the Plus library, applications, and all their dependencies.
+These commands install all prerequisites and builds Plus using default settings:
+
+**Hint:** You can accelerate the compilation process by using parallel jobs; simply pass `-j <number_of_processes>` to the `make` command.
+
+```
+sudo apt update && sudo apt install git git-lfs gcc-11 g++-11 build-essential cmake \
+    qtbase5-dev qt5-qmake qtmultimedia5-dev qttools5-dev libglvnd-dev libqt5xmlpatterns5-dev \
+    qtbase5-private-dev libqt5x11extras5-dev libxt-dev qtdeclarative5-dev libqt5webenginewidgets5 qml-module-qtquick\*
+
+git clone https://github.com/PlusToolkit/PlusBuild.git
+mkdir PlusBuild-bin
+cd PlusBuild-bin
+
+export CC=/usr/bin/gcc-11
+export CXX=/usr/bin/g++-11
+export CPP=$CXX
+export LD=$CXX
+export QT_SELECT=qt5
+
+cmake ../PlusBuild -DCMAKE_BUILD_TYPE=Release
+
+make CC=$CC CXX=$CXX CPP=$CPP LD=$LD 
+```
+
 Ubuntu 22.04 LTS
 ================
 


### PR DESCRIPTION
This PR adds build instructions for Ubuntu 24.04 LTS. The compilation process is similar to that of 22.04, but some changes are necessary:

- The default compiler in Ubuntu 24.04 is GCC 13, which is incompatible with the currently used ITK 5.3 (reference: https://discourse.itk.org/t/building-itk-error-with-algorithim-module/5927 and VTK 9.1. Therefore, we need to manually switch to GCC 11. 
- We need to install `git-lfs` as it is required by ITK.
- We need to specify the QT_SELECT environment variable to ensure `qmlplugindump` uses Qt 5 to avoid the `qmlplugindump: could not find a Qt installation of ''` error, reference (not exactly same): https://askubuntu.com/questions/1460242/ubuntu-22-04-with-qt6-qmake-could-not-find-a-qt-installation-of .
- We need to add the -DCMAKE_BUILD_TYPE=Release flag to `cmake` to avoid the issue https://github.com/PlusToolkit/PlusLib/issues/1096 .

The complete compilation commands are as follows. It has been tested on my Ubuntu 24.04 machine and compiled successfully.

```
sudo apt update && sudo apt install git git-lfs gcc-11 g++-11 build-essential cmake \
    qtbase5-dev qt5-qmake qtmultimedia5-dev qttools5-dev libglvnd-dev libqt5xmlpatterns5-dev \
    qtbase5-private-dev libqt5x11extras5-dev libxt-dev qtdeclarative5-dev libqt5webenginewidgets5 qml-module-qtquick\*

git clone https://github.com/PlusToolkit/PlusBuild.git
mkdir PlusBuild-bin
cd PlusBuild-bin

export CC=/usr/bin/gcc-11
export CXX=/usr/bin/g++-11
export CPP=$CXX
export LD=$CXX
export QT_SELECT=qt5

cmake ../PlusBuild -DCMAKE_BUILD_TYPE=Release

make CC=$CC CXX=$CXX CPP=$CPP LD=$LD 
```